### PR TITLE
Add connect_timeout option to inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,8 @@ The settings available in the triggers and the provisioner are the same.
   * Default: The port that vagrant uses to connect to the machine
 * `sudo_password`
   * Description: A string containing the password bolt will use to escalate privileges on the machine
+* `connect_timeout`
+  * Description: A string which controls if the connection timeout for ssh (linux)
 * `host_key_check`
   * Description: A boolean which controls if the connection should check the host key on the remote host (linux)
   * Default: `false`

--- a/lib/vagrant-bolt/config/global.rb
+++ b/lib/vagrant-bolt/config/global.rb
@@ -10,6 +10,10 @@ class VagrantBolt::Config::Global < Vagrant.plugin('2', :config)
   attr_accessor :boltdir
 
   # @!attribute [rw] host_key_check
+  # @return [String] If the connection should check the host key on the remote host (linux)
+  attr_accessor :connect_timeout
+
+  # @!attribute [rw] host_key_check
   # @return [Boolean] If the connection should check the host key on the remote host (linux)
   attr_accessor :host_key_check
 
@@ -74,45 +78,47 @@ class VagrantBolt::Config::Global < Vagrant.plugin('2', :config)
   attr_accessor :features
 
   def initialize
-    @bolt_exe       = UNSET_VALUE
-    @boltdir        = UNSET_VALUE
-    @host_key_check = UNSET_VALUE
-    @modulepath     = UNSET_VALUE
-    @password       = UNSET_VALUE
-    @port           = UNSET_VALUE
-    @private_key    = UNSET_VALUE
-    @run_as         = UNSET_VALUE
-    @ssl            = UNSET_VALUE
-    @ssl_verify     = UNSET_VALUE
-    @sudo_password  = UNSET_VALUE
-    @tmpdir         = UNSET_VALUE
-    @user           = UNSET_VALUE
-    @verbose        = UNSET_VALUE
-    @debug          = UNSET_VALUE
-    @facts          = UNSET_VALUE
-    @vars           = UNSET_VALUE
-    @features       = UNSET_VALUE
+    @bolt_exe        = UNSET_VALUE
+    @boltdir         = UNSET_VALUE
+    @connect_timeout = UNSET_VALUE
+    @host_key_check  = UNSET_VALUE
+    @modulepath      = UNSET_VALUE
+    @password        = UNSET_VALUE
+    @port            = UNSET_VALUE
+    @private_key     = UNSET_VALUE
+    @run_as          = UNSET_VALUE
+    @ssl             = UNSET_VALUE
+    @ssl_verify      = UNSET_VALUE
+    @sudo_password   = UNSET_VALUE
+    @tmpdir          = UNSET_VALUE
+    @user            = UNSET_VALUE
+    @verbose         = UNSET_VALUE
+    @debug           = UNSET_VALUE
+    @facts           = UNSET_VALUE
+    @vars            = UNSET_VALUE
+    @features        = UNSET_VALUE
   end
 
   def finalize!
-    @bolt_exe       = 'bolt' if @bolt_exe == UNSET_VALUE
-    @boltdir        = '.' if @boltdir == UNSET_VALUE
-    @host_key_check = nil if @host_key_check == UNSET_VALUE
-    @modulepath     = 'modules' if @modulepath == UNSET_VALUE
-    @port           = nil if @port == UNSET_VALUE
-    @password       = nil if @password == UNSET_VALUE
-    @private_key    = nil if @private_key == UNSET_VALUE
-    @run_as         = nil if @run_as == UNSET_VALUE
-    @ssl            = nil if @ssl == UNSET_VALUE
-    @ssl_verify     = nil if @ssl_verify == UNSET_VALUE
-    @sudo_password  = nil if @sudo_password == UNSET_VALUE
-    @tmpdir         = nil if @tmpdir == UNSET_VALUE
-    @user           = nil if @user == UNSET_VALUE
-    @verbose        = nil if @verbose == UNSET_VALUE
-    @debug          = nil if @debug == UNSET_VALUE
-    @facts          = nil if @facts == UNSET_VALUE
-    @features       = nil if @features == UNSET_VALUE
-    @vars           = nil if @vars == UNSET_VALUE
+    @bolt_exe        = 'bolt' if @bolt_exe == UNSET_VALUE
+    @boltdir         = '.' if @boltdir == UNSET_VALUE
+    @connect_timeout = nil if @connect_timeout == UNSET_VALUE
+    @host_key_check  = nil if @host_key_check == UNSET_VALUE
+    @modulepath      = 'modules' if @modulepath == UNSET_VALUE
+    @port            = nil if @port == UNSET_VALUE
+    @password        = nil if @password == UNSET_VALUE
+    @private_key     = nil if @private_key == UNSET_VALUE
+    @run_as          = nil if @run_as == UNSET_VALUE
+    @ssl             = nil if @ssl == UNSET_VALUE
+    @ssl_verify      = nil if @ssl_verify == UNSET_VALUE
+    @sudo_password   = nil if @sudo_password == UNSET_VALUE
+    @tmpdir          = nil if @tmpdir == UNSET_VALUE
+    @user            = nil if @user == UNSET_VALUE
+    @verbose         = nil if @verbose == UNSET_VALUE
+    @debug           = nil if @debug == UNSET_VALUE
+    @facts           = nil if @facts == UNSET_VALUE
+    @features        = nil if @features == UNSET_VALUE
+    @vars            = nil if @vars == UNSET_VALUE
   end
 
   def validate(_machine)
@@ -127,7 +133,7 @@ class VagrantBolt::Config::Global < Vagrant.plugin('2', :config)
     group_objects = ['facts', 'features', 'vars']
     config = {}
     instance_variables_hash.each do |key, value|
-      next if value.nil?
+      next if value.nil? || (value == UNSET_VALUE)
 
       if group_objects.include?(key)
         config[key] = value
@@ -154,6 +160,7 @@ class VagrantBolt::Config::Global < Vagrant.plugin('2', :config)
         'run_as',
         'port',
         'private_key',
+        'connect_timeout',
         'host_key_check',
         'sudo_password',
         'tmpdir',

--- a/lib/vagrant-bolt/config_builder/config.rb
+++ b/lib/vagrant-bolt/config_builder/config.rb
@@ -20,6 +20,10 @@ class VagrantBolt::ConfigBuilder::Config < ConfigBuilder::Model::Base
   # @return [Boolean] Shows debug logging
   def_model_attribute :debug
 
+  # @!attribute [rw] connect_timeout
+  # @return [String] The timeout for the ssh connection (linux)
+  def_model_attribute :connect_timeout
+
   # @!attribute [rw] host_key_check
   # @return [Boolean] If the connection should check the host key on the remote host (linux)
   def_model_attribute :host_key_check
@@ -118,32 +122,33 @@ class VagrantBolt::ConfigBuilder::Config < ConfigBuilder::Model::Base
   def to_proc
     proc do |config|
       bolt = config.bolt
-      with_attr(:args)           { |val| bolt.args           = val }
-      with_attr(:bolt_exe)       { |val| bolt.bolt_exe       = val }
-      with_attr(:command)        { |val| bolt.command        = val }
-      with_attr(:boltdir)        { |val| bolt.boltdir        = val }
-      with_attr(:debug)          { |val| bolt.debug          = val }
-      with_attr(:host_key_check) { |val| bolt.host_key_check = val }
-      with_attr(:modulepath)     { |val| bolt.modulepath     = val }
-      with_attr(:name)           { |val| bolt.name           = val }
-      with_attr(:nodes)          { |val| bolt.nodes          = val }
-      with_attr(:noop)           { |val| bolt.noop           = val }
-      with_attr(:excludes)       { |val| bolt.excludes       = val }
-      with_attr(:node_list)      { |val| bolt.node_list      = val }
-      with_attr(:params)         { |val| bolt.params         = val }
-      with_attr(:user)           { |val| bolt.user           = val }
-      with_attr(:password)       { |val| bolt.password       = val }
-      with_attr(:port)           { |val| bolt.port           = val }
-      with_attr(:private_key)    { |val| bolt.private_key    = val }
-      with_attr(:run_as)         { |val| bolt.run_as         = val }
-      with_attr(:sudo_password)  { |val| bolt.sudo_password  = val }
-      with_attr(:ssl)            { |val| bolt.ssl            = val }
-      with_attr(:ssl_verify)     { |val| bolt.ssl_verify     = val }
-      with_attr(:tmpdir)         { |val| bolt.tmpdir         = val }
-      with_attr(:verbose)        { |val| bolt.verbose        = val }
-      with_attr(:facts)          { |val| bolt.facts          = val }
-      with_attr(:features)       { |val| bolt.features       = val }
-      with_attr(:vars)           { |val| bolt.vars           = val }
+      with_attr(:args)            { |val| bolt.args            = val }
+      with_attr(:bolt_exe)        { |val| bolt.bolt_exe        = val }
+      with_attr(:command)         { |val| bolt.command         = val }
+      with_attr(:boltdir)         { |val| bolt.boltdir         = val }
+      with_attr(:debug)           { |val| bolt.debug           = val }
+      with_attr(:connect_timeout) { |val| bolt.connect_timeout = val }
+      with_attr(:host_key_check)  { |val| bolt.host_key_check  = val }
+      with_attr(:modulepath)      { |val| bolt.modulepath      = val }
+      with_attr(:name)            { |val| bolt.name            = val }
+      with_attr(:nodes)           { |val| bolt.nodes           = val }
+      with_attr(:noop)            { |val| bolt.noop            = val }
+      with_attr(:excludes)        { |val| bolt.excludes        = val }
+      with_attr(:node_list)       { |val| bolt.node_list       = val }
+      with_attr(:params)          { |val| bolt.params          = val }
+      with_attr(:user)            { |val| bolt.user            = val }
+      with_attr(:password)        { |val| bolt.password        = val }
+      with_attr(:port)            { |val| bolt.port            = val }
+      with_attr(:private_key)     { |val| bolt.private_key     = val }
+      with_attr(:run_as)          { |val| bolt.run_as          = val }
+      with_attr(:sudo_password)   { |val| bolt.sudo_password   = val }
+      with_attr(:ssl)             { |val| bolt.ssl             = val }
+      with_attr(:ssl_verify)      { |val| bolt.ssl_verify      = val }
+      with_attr(:tmpdir)          { |val| bolt.tmpdir          = val }
+      with_attr(:verbose)         { |val| bolt.verbose         = val }
+      with_attr(:facts)           { |val| bolt.facts           = val }
+      with_attr(:features)        { |val| bolt.features        = val }
+      with_attr(:vars)            { |val| bolt.vars            = val }
     end
   end
   # rubocop:enable Metrics/BlockLength

--- a/lib/vagrant-bolt/config_builder/provisioner.rb
+++ b/lib/vagrant-bolt/config_builder/provisioner.rb
@@ -20,6 +20,10 @@ class VagrantBolt::ConfigBuilder::Provisioner < ConfigBuilder::Model::Provisione
   # @return [Boolean] Shows debug logging
   def_model_attribute :debug
 
+  # @!attribute [rw] connect_timeout
+  # @return [String] The ssh connection timeout (linux)
+  def_model_attribute :connect_timeout
+
   # @!attribute [rw] host_key_check
   # @return [Boolean] If the connection should check the host key on the remote host (linux)
   def_model_attribute :host_key_check

--- a/lib/vagrant-bolt/version.rb
+++ b/lib/vagrant-bolt/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module VagrantBolt
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end

--- a/spec/unit/config/global_spec.rb
+++ b/spec/unit/config/global_spec.rb
@@ -42,6 +42,7 @@ describe VagrantBolt::Config::Global do
       "run_as",
       "ssl",
       "ssl_verify",
+      "connect_timeout",
       "host_key_check",
       "verbose",
       "debug",

--- a/spec/unit/util/bolt_spec.rb
+++ b/spec/unit/util/bolt_spec.rb
@@ -29,6 +29,7 @@ describe VagrantBolt::Util::Bolt do
         "alias" => "machine",
         "config" => {
           "ssh" => {
+            "connect-timeout" => "30",
             "host-key-check" => false,
             "port" => "22",
             "user" => "vagrant",
@@ -56,6 +57,7 @@ describe VagrantBolt::Util::Bolt do
       config.run_as = 'root'
       config.port = '22'
       config.private_key = 'bar'
+      config.connect_timeout = '30'
       config.host_key_check = false
       config.user = 'vagrant'
       config.facts = { 'a' => 'b' }


### PR DESCRIPTION
Prior to this commit, it was not possible to set the `connect_timeout`
option in the ssh configuration. This commit adds the option.