### PR TITLE
Clean up command line arguments and paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ Gemfile.local
 /modules
 /site-modules
 *.box
+*.rerun.json

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ Gemfile.local
 *.bak
 .vagrant
 /modules
+/site-modules
 *.box

--- a/Puppetfile
+++ b/Puppetfile
@@ -2,6 +2,4 @@
 
 forge "http://forge.puppetlabs.com"
 
-moduledir File.join(File.dirname(__FILE__), 'modules')
-
 mod 'puppetlabs-facts', '0.3.1'

--- a/README.md
+++ b/README.md
@@ -262,7 +262,6 @@ The settings available in the triggers and the provisioner are the same.
   * Description: A boolean which controls if the connection should verify SSL on with WinRM (Windows)
 * `modulepath`
   * Description: A string containing the path to bolt modules
-  * Default: `modules` in the vagrant root
 * `tmpdir`
   * Description: A string containing the directory to upload and execute temporary files on the target
 * `verbose`

--- a/lib/vagrant-bolt/command.rb
+++ b/lib/vagrant-bolt/command.rb
@@ -46,7 +46,7 @@ class VagrantBolt::Command < Vagrant.plugin('2', :command)
   # @param args [Array<String>] An array containing the bolt arguments
   def execute_bolt_command(args)
     bolt_exe = @env.vagrantfile.config.bolt.bolt_exe
-    boltdir = VagrantBolt::Util::Config.full_path(@env.vagrantfile.config.bolt.boltdir, @env.root_path)
+    boltdir = VagrantBolt::Util::Config.relative_path(@env.vagrantfile.config.bolt.boltdir, @env.root_path)
     inventoryfile = VagrantBolt::Util::Bolt.inventory_file(@env)
 
     quoted_args = args.flatten.compact.map { |a| "'#{a}'" }

--- a/lib/vagrant-bolt/command.rb
+++ b/lib/vagrant-bolt/command.rb
@@ -42,11 +42,10 @@ class VagrantBolt::Command < Vagrant.plugin('2', :command)
     execute_bolt_command(bolt_args)
   end
 
-  # Run a bolt command with the inventory path, module path, and boltdir
+  # Run a bolt command with the inventory path, and boltdir
   # @param args [Array<String>] An array containing the bolt arguments
   def execute_bolt_command(args)
     bolt_exe = @env.vagrantfile.config.bolt.bolt_exe
-    modulepath = VagrantBolt::Util::Config.full_path(@env.vagrantfile.config.bolt.modulepath, @env.root_path)
     boltdir = VagrantBolt::Util::Config.full_path(@env.vagrantfile.config.bolt.boltdir, @env.root_path)
     inventoryfile = VagrantBolt::Util::Bolt.inventory_file(@env)
 
@@ -54,8 +53,6 @@ class VagrantBolt::Command < Vagrant.plugin('2', :command)
     command = [
       "\'#{bolt_exe}\'",
       quoted_args,
-      '--modulepath',
-      "\'#{modulepath}\'",
       '--boltdir',
       "\'#{boltdir}\'",
     ]

--- a/lib/vagrant-bolt/config/global.rb
+++ b/lib/vagrant-bolt/config/global.rb
@@ -18,7 +18,7 @@ class VagrantBolt::Config::Global < Vagrant.plugin('2', :config)
   attr_accessor :host_key_check
 
   # @!attribute [rw] modulepath
-  # @return [String] The path to the modules. Defaults to `modules`.
+  # @return [String] The path to the modules.
   attr_accessor :modulepath
 
   # @!attribute [rw] user
@@ -104,7 +104,7 @@ class VagrantBolt::Config::Global < Vagrant.plugin('2', :config)
     @boltdir         = '.' if @boltdir == UNSET_VALUE
     @connect_timeout = nil if @connect_timeout == UNSET_VALUE
     @host_key_check  = nil if @host_key_check == UNSET_VALUE
-    @modulepath      = 'modules' if @modulepath == UNSET_VALUE
+    @modulepath      = nil if @modulepath == UNSET_VALUE
     @port            = nil if @port == UNSET_VALUE
     @password        = nil if @password == UNSET_VALUE
     @private_key     = nil if @private_key == UNSET_VALUE

--- a/lib/vagrant-bolt/config_builder/config.rb
+++ b/lib/vagrant-bolt/config_builder/config.rb
@@ -29,7 +29,7 @@ class VagrantBolt::ConfigBuilder::Config < ConfigBuilder::Model::Base
   def_model_attribute :host_key_check
 
   # @!attribute [rw] modulepath
-  # @return [String] The path to the modules. Defaults to `modules`.
+  # @return [String] The path to the modules.
   def_model_attribute :modulepath
 
   # @!attribute [rw] name

--- a/lib/vagrant-bolt/config_builder/provisioner.rb
+++ b/lib/vagrant-bolt/config_builder/provisioner.rb
@@ -29,7 +29,7 @@ class VagrantBolt::ConfigBuilder::Provisioner < ConfigBuilder::Model::Provisione
   def_model_attribute :host_key_check
 
   # @!attribute [rw] modulepath
-  # @return [String] The path to the modules. Defaults to `modules`.
+  # @return [String] The path to the modules.
   def_model_attribute :modulepath
 
   # @!attribute [rw] name

--- a/lib/vagrant-bolt/runner.rb
+++ b/lib/vagrant-bolt/runner.rb
@@ -50,8 +50,8 @@ class VagrantBolt::Runner
     config.node_list ||= @machine.name.to_s unless config.excludes.include?(@machine.name.to_s)
 
     # Ensure these are absolute paths to allow for running vagrant commands outside of the root dir
-    config.modulepath = VagrantBolt::Util::Config.full_path(config.modulepath, @env.root_path)
-    config.boltdir = VagrantBolt::Util::Config.full_path(config.boltdir, @env.root_path)
+    config.modulepath = VagrantBolt::Util::Config.relative_path(config.modulepath, @env.root_path)
+    config.boltdir = VagrantBolt::Util::Config.relative_path(config.boltdir, @env.root_path)
 
     config
   end

--- a/lib/vagrant-bolt/util/bolt.rb
+++ b/lib/vagrant-bolt/util/bolt.rb
@@ -108,7 +108,7 @@ module VagrantBolt::Util
     # @param env [Object] The environment
     # @return [String] The path to the inventory file
     def self.inventory_file(env)
-      File.join(env.local_data_path, 'bolt_inventory.yaml')
+      VagrantBolt::Util::Config.relative_path('bolt_inventory.yaml', env.local_data_path)
     end
 
     # Update and write the inventory file for the current running machines

--- a/lib/vagrant-bolt/util/config.rb
+++ b/lib/vagrant-bolt/util/config.rb
@@ -32,7 +32,7 @@ module VagrantBolt::Util
       result
     end
 
-    # Convert a path to the absolute path of the inventory if it is relative
+    # Convert a path to the absolute path if it is relative
     # @param path [String] The path to convert
     # @param root_path [Object] The root path to append
     # @return [String] The absolute path or nil if path is nil
@@ -40,6 +40,17 @@ module VagrantBolt::Util
       return path if path.nil? || root_path.nil?
 
       (Pathname.new path).absolute? ? path : File.expand_path(path, root_path)
+    end
+
+    # Convert a path to the relative path from the current directory
+    # @param path [String] The path to convert
+    # @param root_path [Object] The root path to append
+    # @return [String] The relative path or nil if path is nil
+    def self.relative_path(path, root_path)
+      return path if path.nil?
+
+      absolute_path = Pathname.new full_path(path, root_path)
+      absolute_path.relative_path_from(Pathname.getwd).to_s
     end
   end
 end

--- a/spec/unit/config/global_spec.rb
+++ b/spec/unit/config/global_spec.rb
@@ -21,7 +21,6 @@ describe VagrantBolt::Config::Global do
 
   context "defaults" do
     expected_values = {
-      modulepath: "modules",
       bolt_exe: "bolt",
       boltdir: ".",
     }
@@ -49,6 +48,7 @@ describe VagrantBolt::Config::Global do
       "facts",
       "vars",
       "features",
+      "modulepath",
     ]
     expected_nil.each do |val|
       it "defaults #{val} to nil" do

--- a/spec/unit/runner/runner_spec.rb
+++ b/spec/unit/runner/runner_spec.rb
@@ -28,13 +28,11 @@ describe VagrantBolt::Runner do
       allow(result).to receive(:stderr).and_return("")
     end
   end
-  let(:root_path) { '/root/path' }
-  let(:local_data_path) { '/local/data/path' }
-  let(:inventory_path) { "#{local_data_path}/bolt_inventory.yaml" }
+  let(:root_path) { Dir.getwd }
+  let(:local_data_path) { "#{root_path}/.vagrant" }
+  let(:inventory_path) { ".vagrant/bolt_inventory.yaml" }
   before(:each) do
     allow(VagrantBolt::Util::Bolt).to receive(:update_inventory_file).with(iso_env).and_return(inventory_path)
-    allow(iso_env).to receive(:root_path).and_return(root_path)
-    allow(iso_env).to receive(:local_data_path).and_return(local_data_path)
     allow(machine).to receive(:env).and_return(:iso_env)
     allow(machine).to receive(:ssh_info).and_return(
       host: 'foo',
@@ -94,6 +92,8 @@ describe VagrantBolt::Runner do
     let(:options) { { notify: [:stdout, :stderr], env: { PATH: nil } } }
     before(:each) do
       allow(Vagrant::Util::Subprocess).to receive(:execute).and_return(subprocess_result)
+      allow(iso_env).to receive(:root_path).and_return(root_path)
+      allow(iso_env).to receive(:local_data_path).and_return(local_data_path)
     end
 
     it 'does not raise an exeption when all parameters are specified' do
@@ -110,11 +110,10 @@ describe VagrantBolt::Runner do
 
     it 'creates a shell execution' do
       config.bolt_exe = 'bolt'
-      config.modulepath = 'modules'
       config.boltdir = '.'
       config.node_list = 'ssh://test:22'
       config.finalize!
-      command = "bolt task run 'foo' --boltdir '#{root_path}' --modulepath '#{root_path}/modules' --inventoryfile '#{inventory_path}' --nodes 'ssh://test:22'"
+      command = "bolt task run 'foo' --boltdir '.' --inventoryfile '#{inventory_path}' --nodes 'ssh://test:22'"
       expect(Vagrant::Util::Subprocess).to receive(:execute).with('bash', '-c', command, options).and_return(subprocess_result)
       subject.run('task', 'foo')
     end


### PR DESCRIPTION
This PR changes the command line arguments for the bolt command to simplify them. It removes the default `modulepath` as it should be already contained in the `boltdir`. It also converts the absolute paths to relative paths for the directories.  Both of these changes combine to significantly decrease the command length that is used when running bolt commands.