### PR TITLE
Add changelog generation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ group :development do
   gem 'rubocop'
   gem 'rubocop-rspec'
   gem 'yard', '~> 0.9.16'
+  gem 'github_changelog_generator'
 end
 
 group :test do

--- a/tasks/changelog.rake
+++ b/tasks/changelog.rake
@@ -1,0 +1,8 @@
+require 'github_changelog_generator/task'
+require_relative '../lib/vagrant-bolt/version'
+
+GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+  config.user ='oscar-stack'
+  config.project = 'vagrant-bolt'
+  config.future_release = VagrantBolt::VERSION
+end


### PR DESCRIPTION
This commit implements github-changelog-generator as a rake task in the
repo to assist with generation and release of the module.