### PR TITLE
Fix changelog version tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 
-## [0.1.1](https://github.com/oscar-stack/vagrant-bolt/tree/0.1.1) (2019-07-01)
-[Full Changelog](https://github.com/oscar-stack/vagrant-bolt/compare/v0.1.0...0.1.1)
+## [v0.1.1](https://github.com/oscar-stack/vagrant-bolt/tree/v0.1.1) (2019-07-01)
+[Full Changelog](https://github.com/oscar-stack/vagrant-bolt/compare/v0.1.0...v0.1.1)
 
 **Merged pull requests:**
 

--- a/tasks/changelog.rake
+++ b/tasks/changelog.rake
@@ -4,5 +4,5 @@ require_relative '../lib/vagrant-bolt/version'
 GitHubChangelogGenerator::RakeTask.new :changelog do |config|
   config.user ='oscar-stack'
   config.project = 'vagrant-bolt'
-  config.future_release = VagrantBolt::VERSION
+  config.future_release = "v#{VagrantBolt::VERSION}"
 end


### PR DESCRIPTION
Prior to this commit, the future version generation did not prepend the
`v` to the tag so it was `0.1.1` instead of `v0.1.1`, which caused the
links to be incorrect. This commit prepends the `v` to the version to
simulate the tag.