### PR TITLE
Update to Bolt inventory v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ Gemfile.local
 /site-modules
 *.box
 *.rerun.json
+.resource_types

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -96,14 +96,6 @@ Metrics/CyclomaticComplexity:
   Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false
-Metrics/MethodLength:
-  Enabled: true
-  ExcludedMethods:
-    - initialize
-    - finalize!
-    - validate
-    - to_proc
-  Max: 25
 Metrics/ClassLength:
   Enabled: false
 Metrics/ModuleLength:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,6 @@ matrix:
   fast_finish: true
   include:
     - rvm: 2.4.4
-      env: TEST_VAGRANT_VERSION=v2.2.2
+      env: TEST_VAGRANT_VERSION=v2.2.7
     - rvm: 2.5.0
       env: TEST_VAGRANT_VERSION=HEAD

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,9 @@
 
 source 'https://rubygems.org'
 require 'rubygems/version'
+ruby ">= 2.5.0"
 
-vagrant_branch = ENV['TEST_VAGRANT_VERSION'] || 'v2.2.2'
+vagrant_branch = ENV['TEST_VAGRANT_VERSION'] || 'v2.2.7'
 
 group :plugins do
   gemspec
@@ -31,7 +32,7 @@ group :test do
 end
 
 group :system_tests do
-  gem 'bolt', ">=1.5.0"
+  gem 'bolt', "~> 1.48.0"
 end
 
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@
 
 source 'https://rubygems.org'
 require 'rubygems/version'
-ruby ">= 2.5.0"
 
 vagrant_branch = ENV['TEST_VAGRANT_VERSION'] || 'v2.2.7'
 

--- a/acceptance/components/bolt_spec.rb
+++ b/acceptance/components/bolt_spec.rb
@@ -24,7 +24,7 @@ shared_examples 'provider/virtualbox' do |provider, options|
       expect(@result.stdout).to match(%r{Bolt: Running bolt command locally: \/[^\ ]+bolt task run 'facts'})
       expect(@result.stdout).to match(%r{Bolt: Running bolt command locally: \/[^\ ]+bolt plan run 'facts'})
       expect(@result.stdout).to match(%r{Bolt: Running bolt command locally: \/[^\ ]+bolt command run})
-      expect(@result.stdout.scan(%r{Successful on 1 node}).size).to eq(3)
+      expect(@result.stdout.scan(%r{Successful on 1 target}).size).to eq(3)
     end
   end
 
@@ -39,7 +39,7 @@ shared_examples 'provider/virtualbox' do |provider, options|
       expect(@result.stdout).to match(%r{Bolt: Running bolt command locally: \/[^\ ]+bolt task run 'facts'})
       expect(@result.stdout).to match(%r{Bolt: Running bolt command locally: \/[^\ ]+bolt plan run 'facts'})
       expect(@result.stdout).to match(%r{Bolt: Running bolt command locally: \/[^\ ]+bolt command run})
-      expect(@result.stdout.scan(%r{Successful on 1 node}).size).to eq(3)
+      expect(@result.stdout.scan(%r{Successful on 1 target}).size).to eq(3)
     end
   end
 
@@ -50,18 +50,18 @@ shared_examples 'provider/virtualbox' do |provider, options|
 
     it 'runs a task, plan, and command' do
       expect(@result.exit_code).to eq(0)
-      result = assert_execute('vagrant', 'bolt', 'task', 'run', 'facts', '-n', 'server')
+      result = assert_execute('vagrant', 'bolt', 'task', 'run', 'facts', '-t', 'server')
       expect(result.exit_code).to eq(0)
       expect(result.stdout).to match(%r{Bolt: Running bolt command locally: '\/[^\ ]+bolt' 'task' 'run' 'facts'})
-      expect(result.stdout.scan(%r{Successful on 1 node}).size).to eq(1)
-      result = assert_execute('vagrant', 'bolt', 'plan', 'run', 'facts', '-n', 'server')
+      expect(result.stdout.scan(%r{Successful on 1 target}).size).to eq(1)
+      result = assert_execute('vagrant', 'bolt', 'plan', 'run', 'facts', '-t', 'server')
       expect(result.exit_code).to eq(0)
       expect(result.stdout).to match(%r{Bolt: Running bolt command locally: '\/[^\ ]+bolt' 'plan' 'run' 'facts'})
-      expect(result.stdout.scan(%r{Successful on 1 node}).size).to eq(1)
-      result = assert_execute('vagrant', 'bolt', 'command', 'run', 'hostname', '-n', 'server')
+      expect(result.stdout.scan(%r{Successful on 1 target}).size).to eq(1)
+      result = assert_execute('vagrant', 'bolt', 'command', 'run', 'hostname', '-t', 'server')
       expect(result.exit_code).to eq(0)
       expect(result.stdout).to match(%r{Bolt: Running bolt command locally: '\/[^\ ]+bolt' 'command' 'run'})
-      expect(result.stdout.scan(%r{Successful on 1 node}).size).to eq(1)
+      expect(result.stdout.scan(%r{Successful on 1 target}).size).to eq(1)
     end
   end
 
@@ -86,7 +86,7 @@ shared_examples 'provider/virtualbox' do |provider, options|
       # Ensure that the root level `run_as` is used
       expect(result.stdout).to match(%r{Bolt: Running bolt command locally: \/[^\ ]+bolt command run[^\n]+allnodetest[^\n]+--run-as 'root'})
       ## Configtest
-      # Ensure excludes overrides nodes
+      # Ensure excludes overrides targets
       expect(result.stdout).to match(%r{Bolt: Running bolt command locally: \/[^\ ]+bolt command run[^\n]+configtest[^\n]+server2})
       # Ensure verbose and debug flags are correctly handled
       expect(result.stdout).to match(%r{Bolt: Running bolt command locally: \/[^\ ]+bolt command run[^\n]+configtest[^\n]+--verbose})

--- a/lib/vagrant-bolt/config_builder/monkey_patches.rb
+++ b/lib/vagrant-bolt/config_builder/monkey_patches.rb
@@ -29,7 +29,7 @@ module VagrantBolt::ConfigBuilder::MonkeyPatches
 
   def eval_bolt_triggers_root(vm_root_config)
     # Configure the vm bolt object if the options exist
-    triggers = attr(:bolt_triggers) || [] # rubocop:disable Style/Attr
+    triggers = attr(:bolt_triggers) || []
     triggers.each do |config|
       f = VagrantBolt::ConfigBuilder::Triggers.new_from_hash(config)
       f.call(vm_root_config)

--- a/lib/vagrant-bolt/util/bolt.rb
+++ b/lib/vagrant-bolt/util/bolt.rb
@@ -36,7 +36,7 @@ module VagrantBolt::Util
       end
 
       command << "--inventoryfile \'#{inventory_path}\'" unless inventory_path.nil?
-      command << "--nodes \'#{config.node_list}\'" unless config.node_list.nil?
+      command << "--targets \'#{config.node_list}\'" unless config.node_list.nil?
       command << config.args unless config.args.nil?
       command.flatten.join(" ")
     end
@@ -45,12 +45,12 @@ module VagrantBolt::Util
     # @param env [Object] The env object
     # @return [Hash] The hash of config options for the inventory.yaml
     def self.generate_inventory_hash(env)
-      inventory = { 'nodes' => [] }
+      inventory = { 'version' => 2, 'targets' => [] }
       inventory.merge!(env.vagrantfile.config.bolt.inventory_config.compact)
       VagrantBolt::Util::Machine.nodes_in_environment(env).each do |vm|
         next unless VagrantBolt::Util::Machine.running?(vm)
 
-        inventory['nodes'] << generate_node_hash(vm)
+        inventory['targets'] << generate_node_hash(vm)
       end
       inventory.compact
     end
@@ -70,7 +70,7 @@ module VagrantBolt::Util
       transport = VagrantBolt::Util::Machine.windows?(machine) ? 'winrm' : 'ssh'
       node_hash['config'][transport] = machine_transport_hash(machine, machine_config, ssh_info).compact
       node_hash['config']['transport'] = transport
-      node_hash['name'] = "#{transport}://#{ssh_info[:host]}:#{node_hash['config'][transport]['port']}"
+      node_hash['uri'] = "#{transport}://#{ssh_info[:host]}:#{node_hash['config'][transport]['port']}"
       machine_config.each do |key, value|
         next if key == 'config' || value.nil? || value.empty?
 

--- a/lib/vagrant-bolt/version.rb
+++ b/lib/vagrant-bolt/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module VagrantBolt
-  VERSION = '0.1.3'
+  VERSION = '0.2.0'
 end

--- a/spec/unit/runner/runner_spec.rb
+++ b/spec/unit/runner/runner_spec.rb
@@ -113,7 +113,7 @@ describe VagrantBolt::Runner do
       config.boltdir = '.'
       config.node_list = 'ssh://test:22'
       config.finalize!
-      command = "bolt task run 'foo' --boltdir '.' --inventoryfile '#{inventory_path}' --nodes 'ssh://test:22'"
+      command = "bolt task run 'foo' --boltdir '.' --inventoryfile '#{inventory_path}' --targets 'ssh://test:22'"
       expect(Vagrant::Util::Subprocess).to receive(:execute).with('bash', '-c', command, options).and_return(subprocess_result)
       subject.run('task', 'foo')
     end

--- a/spec/unit/util/bolt_spec.rb
+++ b/spec/unit/util/bolt_spec.rb
@@ -39,7 +39,7 @@ describe VagrantBolt::Util::Bolt do
           },
           "transport" => "ssh",
         },
-        "name" => "ssh://machine:22",
+        "uri" => "ssh://machine:22",
         "facts" => { 'a' => 'b' },
         "vars" => { 'foo' => 'bar' },
         "features" => ['foo'],
@@ -48,8 +48,9 @@ describe VagrantBolt::Util::Bolt do
     let(:config_hash) { { 'config' => { 'a' => 'b' } } }
     let(:node_hash) do
       {
-        'nodes' => [machine_hash],
+        'targets' => [machine_hash],
         'config' => config_hash['config'],
+        'version' => 2,
       }
     end
     before(:each) do
@@ -95,7 +96,7 @@ describe VagrantBolt::Util::Bolt do
       config.node_list = 'ssh://test:22'
       config.user = 'user'
       config.finalize!
-      expected = "bolt task run 'foo' --user \'user\' --inventoryfile '#{inventory_path}' --nodes \'ssh://test:22\'"
+      expected = "bolt task run 'foo' --user \'user\' --inventoryfile '#{inventory_path}' --targets \'ssh://test:22\'"
       expect(subject.generate_bolt_command(config, inventory_path)).to eq(expected)
     end
 


### PR DESCRIPTION
Prior to this commit, the bolt inventory file was version 1 compatible.
In bolt 2.0.0, inventory v1 was dropped so this plugin was no longer
compatible with bolt 2.0.0+. This commit convertes the bolt inventory to
v2, updates the spec and acceptance tests to check for compatiblity with
bolt 1.48 and above.