### PR TITLE
Fix config builder role filtering

### DIFF
--- a/lib/vagrant-bolt/config_builder/monkey_patches.rb
+++ b/lib/vagrant-bolt/config_builder/monkey_patches.rb
@@ -47,7 +47,7 @@ ConfigBuilder::Model::VM.prepend(VagrantBolt::ConfigBuilder::MonkeyPatches)
 # Allow for the role filter to handle bolt configs and bolt_triggers
 # @!visibility private
 module VagrantBolt::ConfigBuilder::MonkeyPatches::FilterRoles
-  def merge_targets!(left, right)
+  def merge_nodes!(left, right)
     super.tap do |result|
       array_keys = ['bolt_triggers']
       array_keys.each do |key|

--- a/lib/vagrant-bolt/version.rb
+++ b/lib/vagrant-bolt/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module VagrantBolt
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end


### PR DESCRIPTION
This PR fixes an issue bolt triggers were not showing up when using config builder and roles. Without roles it would work, but when adding triggers in a role, the trigger would not be present.