### PR TITLE
Fix config.debug = true for Bolt 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ Requirements
 ------------
 
 * Vagrant 2.2.0+ is required for this plugin.
-* Bolt 2.16+ needs to be installed on the platform machine and accessible on the path. Use the `bolt_exe` config parameter if it is not on the path.
+* Bolt 2.17+ needs to be installed on the platform machine and accessible on the path. Use the `bolt_exe` config parameter if it is not on the path.
 * Ruby 2.5+
 
 Known Issues

--- a/lib/vagrant-bolt/util/bolt.rb
+++ b/lib/vagrant-bolt/util/bolt.rb
@@ -26,7 +26,12 @@ module VagrantBolt::Util
           # Verbose and debug do not have --no flags so exclude them
           next if ['verbose', 'debug', 'noop'].include?(key) && !value
 
-          arg = value ? "--#{key}" : "--no-#{key}"
+          arg = if key == 'debug'
+                  '--log-level=debug'
+                else
+                  value ? "--#{key}" : "--no-#{key}"
+                end
+
           command << arg
         when String
           command << "--#{key} \'#{value}\'"

--- a/spec/unit/util/bolt_spec.rb
+++ b/spec/unit/util/bolt_spec.rb
@@ -144,7 +144,7 @@ describe VagrantBolt::Util::Bolt do
       config.verbose = true
       config.noop = true
       config.finalize!
-      expected = "bolt task run 'foo' --verbose --debug --noop --inventoryfile '#{inventory_path}'"
+      expected = "bolt task run 'foo' --verbose --log-level=debug --noop --inventoryfile '#{inventory_path}'"
       expect(subject.generate_bolt_command(config, inventory_path)).to eq(expected)
     end
 


### PR DESCRIPTION
This patch replaces the bolt option `--debug` (removed in Bolt 3.0) with
`--log-level=debug` (introduced in Bolt 2.17)

Fixes #19 